### PR TITLE
Allow fetching large number of Pocket items #22

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -89,39 +89,36 @@ exports.sourceNodes = async (
   );
 
   // Fetch up to apiMaxRecordsToReturn from Pocket API. If more than maxItemsToFetchInOneCall, do it in several requests.
-  var done = false;
-  var i = 0;
-  var itemsFetched = 0;
-  var maxItemsToFetchInOneCall = 5000;
-  var totalItemsToFetch = pocketCallParams.count;
+  var done = false
+  var i = 0
+  var itemsFetched = 0
+  var maxItemsToFetchInOneCall = 5000
+  var totalItemsToFetch = pocketCallParams.count
   if (totalItemsToFetch > maxItemsToFetchInOneCall) {
     // apiMaxRecordsToReturn (= pocketCallParams.count) contains the TOTAL number of items to be returned.
     // So if it's higher than maxItemsToFetchInOneCall, adjust the number of items to fetch per call.
-    pocketCallParams.count = maxItemsToFetchInOneCall;
+    pocketCallParams.count = maxItemsToFetchInOneCall
   }
-  var allFetchedItems = {};
+  var allFetchedItems = {}
   while (done === false) {
-    pocketCallParams.sort = 'newest';
-    pocketCallParams.offset = i * maxItemsToFetchInOneCall;
+    pocketCallParams.sort = 'newest'
+    pocketCallParams.offset = i*maxItemsToFetchInOneCall
     var resp = await pocketService
       .fetchArticles(pocketClient, pocketCallParams)
       .catch((e) => console.log(e));
     if (Object.keys(resp.list).length === 0) {
-      done = true;
-    } else {
-      allFetchedItems = Object.assign(allFetchedItems, resp.list);
+      done = true
     }
-    itemsFetched = itemsFetched + Object.keys(resp.list).length;
-    if (itemsFetched >= totalItemsToFetch) done = true;
-    i++;
+    else {
+      allFetchedItems = Object.assign(allFetchedItems, resp.list)
+    }
+    itemsFetched = itemsFetched + Object.keys(resp.list).length
+    if (itemsFetched >= totalItemsToFetch) done = true
+    i++
   }
   // Put the result in property "list" of object "resp".
-  resp = { list: allFetchedItems };
-  reporter.info(
-    '[gatsby-source-pocket] Fetched ' +
-      Object.keys(allFetchedItems).length +
-      ' Pocket items'
-  );
+  resp = { list: allFetchedItems} 
+  reporter.info('[gatsby-source-pocket] Fetched ' + Object.keys(allFetchedItems).length + " Pocket items")
 
   const data = pocketResponseToArticlesArray(resp);
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,9 +1,9 @@
-const pocketService = require('./pockerService');
-const startOfDay = require('date-fns/startOfDay');
-const startOfWeek = require('date-fns/startOfWeek');
-const format = require('date-fns/format');
-const subWeeks = require('date-fns/subWeeks');
-const { URL } = require('url');
+const pocketService = require("./pockerService");
+const startOfDay = require("date-fns/startOfDay");
+const startOfWeek = require("date-fns/startOfWeek");
+const format = require("date-fns/format");
+const subWeeks = require("date-fns/subWeeks");
+const { URL } = require("url");
 
 function getUnixTimeToGetArticlesFrom(pluginOptions) {
   // get the data since the last time it was run, or from the earliest week
@@ -13,7 +13,7 @@ function getUnixTimeToGetArticlesFrom(pluginOptions) {
   );
 
   // override - usually used in prod just to update current and last week on a nightly update after the first full generation.
-  if (pluginOptions.getCurrentWeekOnly.toLowerCase() === 'y') {
+  if (pluginOptions.getCurrentWeekOnly.toLowerCase() === "y") {
     lastGeneratedDateStamp = startOfWeek(subWeeks(new Date(), 1));
   }
 
@@ -22,7 +22,7 @@ function getUnixTimeToGetArticlesFrom(pluginOptions) {
   );
 
   if (isNaN(unixTimeToGetArticlesFrom)) {
-    throw new Error('set a pocket start date in options');
+    throw new Error("set a pocket start date in options");
   }
 
   return unixTimeToGetArticlesFrom;
@@ -32,9 +32,9 @@ function getApiParamOptions(unixTimeToGetArticlesFrom, pluginOptions) {
   // get/retrieve/search parameters.
   // See https://getpocket.com/developer/docs/v3/retrieve for full list of available params.
   let params = {
-    sort: 'newest',
+    sort: "newest",
     count: parseInt(pluginOptions.apiMaxRecordsToReturn),
-    detailType: 'complete',
+    detailType: "complete",
     state: pluginOptions.stateFilterString,
     since: unixTimeToGetArticlesFrom,
   };
@@ -68,7 +68,7 @@ function pocketResponseToArticlesArray(pocketApiResults) {
   );
 }
 
-const POCKET_ARTICLE_NODE_TYPE = 'PocketArticle';
+const POCKET_ARTICLE_NODE_TYPE = "PocketArticle";
 
 exports.sourceNodes = async (
   { actions, createNodeId, createContentDigest, getNodesByType, reporter },
@@ -138,21 +138,13 @@ exports.sourceNodes = async (
 
     const articleDomain = Boolean(datum.resolved_url)
       ? new URL(datum.resolved_url).hostname
-      : '';
+      : "";
 
     const tags = datum.tags ? Object.keys(datum.tags) : [];
 
-    const readDay = datum.time_read
-      ? parseInt(
-          format(startOfDay(new Date(parseInt(datum.time_read) * 1000)), 'X')
-        )
-      : 0;
+    const readDay = datum.time_read ? parseInt(format(startOfDay(new Date(parseInt(datum.time_read) * 1000)), "X")) : 0
 
-    const readWeek = datum.time_read
-      ? parseInt(
-          format(startOfWeek(new Date(parseInt(datum.time_read) * 1000)), 'X')
-        )
-      : 0;
+    const readWeek = datum.time_read ? parseInt(format(startOfWeek(new Date(parseInt(datum.time_read) * 1000)), "X")) : 0
 
     createNode({
       id: createNodeId(`${POCKET_ARTICLE_NODE_TYPE}-${datum.item_id}`),


### PR DESCRIPTION
Fetch up to apiMaxRecordsToReturn from Pocket API. 
If there are more than maxItemsToFetchInOneCall (hard-coded to 5000) to fetch, do it in several requests.

Closes #22