### PR TITLE
Allow fetching large number of Pocket items

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -71,7 +71,7 @@ function pocketResponseToArticlesArray(pocketApiResults) {
 const POCKET_ARTICLE_NODE_TYPE = "PocketArticle";
 
 exports.sourceNodes = async (
-  { actions, createNodeId, createContentDigest, getNodesByType },
+  { actions, createNodeId, createContentDigest, getNodesByType, reporter },
   pluginOptions
 ) => {
   const { createNode, touchNode } = actions;
@@ -88,9 +88,37 @@ exports.sourceNodes = async (
     pluginOptions
   );
 
-  const resp = await pocketService
-    .fetchArticles(pocketClient, pocketCallParams)
-    .catch((e) => console.log(e));
+  // Fetch up to apiMaxRecordsToReturn from Pocket API. If more than maxItemsToFetchInOneCall, do it in several requests.
+  var done = false
+  var i = 0
+  var itemsFetched = 0
+  var maxItemsToFetchInOneCall = 5000
+  var totalItemsToFetch = pocketCallParams.count
+  if (totalItemsToFetch > maxItemsToFetchInOneCall) {
+    // apiMaxRecordsToReturn (= pocketCallParams.count) contains the TOTAL number of items to be returned.
+    // So if it's higher than maxItemsToFetchInOneCall, adjust the number of items to fetch per call.
+    pocketCallParams.count = maxItemsToFetchInOneCall
+  }
+  var allFetchedItems = {}
+  while (done === false) {
+    pocketCallParams.sort = 'newest'
+    pocketCallParams.offset = i*maxItemsToFetchInOneCall
+    var resp = await pocketService
+      .fetchArticles(pocketClient, pocketCallParams)
+      .catch((e) => console.log(e));
+    if (Object.keys(resp.list).length === 0) {
+      done = true
+    }
+    else {
+      allFetchedItems = Object.assign(allFetchedItems, resp.list)
+    }
+    itemsFetched = itemsFetched + Object.keys(resp.list).length
+    if (itemsFetched >= totalItemsToFetch) done = true
+    i++
+  }
+  // Put the result in property "list" of object "resp".
+  resp = { list: allFetchedItems} 
+  reporter.info('[gatsby-source-pocket] Fetched ' + Object.keys(allFetchedItems).length + " Pocket items")
 
   const data = pocketResponseToArticlesArray(resp);
 


### PR DESCRIPTION
Fetch up to apiMaxRecordsToReturn from Pocket API.
If there are more than maxItemsToFetchInOneCall (hard-coded to 5000) to fetch, do it in several requests.

Closes https://github.com/conradj/gatsby-source-pocket/issues/22